### PR TITLE
Hashbang compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ following instructions to jumb back to them.
 ```
   _  jump to first | to the left
   =  jump to first | to the right
-  #  jump to the nth occurence of |, according to current value
+  $  jump to the nth occurence of |, according to current value
 ```
 
 ### Conditions

--- a/examples/cat.duh
+++ b/examples/cat.duh
@@ -12,7 +12,7 @@ oooooooooooooooooooooooooooooooooooooooo
 |:;
  ----------
  &=
- ~+++#
+ ~+++$
 |++++++++++)@
 
 |~'

--- a/keycodes.h
+++ b/keycodes.h
@@ -25,7 +25,7 @@
 /* Jumping instructions */
 #define JMP_LEFT 95  // _  jump to first mark to the left
 #define JMP_RGHT 61  // =  jump to first mark to the right
-#define JMP_GOTO 35  // #  jump to mark by value
+#define JMP_GOTO 36  // $  jump to mark by value
 
 /* Conditions */
 #define CND_SKIP 38  // & if value is zero, skip next instruction


### PR DESCRIPTION
Duh is nearly compatible with the hashbang syntax. The only thing that conflicts is the # instruction. This PR renames it to $ to resolve this collision and allow hashbangs to be used.